### PR TITLE
fix: fixes homepage video widths for mobile

### DIFF
--- a/app/components/atoms/VideoPlayer/VideoPlayer.tsx
+++ b/app/components/atoms/VideoPlayer/VideoPlayer.tsx
@@ -9,8 +9,8 @@ const VideoPlayer = ({ data }: any) => {
   const [ref, rect] = useResizeObserver()
 
   useEffect(() => {
-    if (rect.width !== undefined) {
-      setHeight(sixteenByNine(rect.width))
+    if (rect?.width !== undefined) {
+      setHeight(sixteenByNine(rect?.width))
     } else {
       setHeight(0)
     }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,5 @@
-import { Divider, Group, Title } from '@mantine/core'
+import { Divider, Group, Stack, Title } from '@mantine/core'
+import { useElementSize } from '@mantine/hooks'
 import type { LoaderFunction, MetaFunction } from '@remix-run/node'
 import { Link, useLoaderData } from '@remix-run/react'
 import VideoPlayer from '~/components/atoms/VideoPlayer'
@@ -47,19 +48,29 @@ export const loader: LoaderFunction = async () => {
 
 export default function Index() {
   const { YTVideoData, channelData }: any = useLoaderData()
-  console.log('channel', channelData)
+  const { ref, width, height } = useElementSize()
+  console.log(ref, width)
   return (
     <>
       {channelData && <Hpabout channelData={channelData} />}
       {YTVideoData !== null && (
         <>
-          <Divider mt="md" />
+          <Divider mt="md" ref={ref} />
           <Title order={2} ta="center" mb="lg" mt="xl">{`Recent Videos`}</Title>
-          <Group align="center" justify="center" grow>
-            {YTVideoData?.items?.map((video: any, index: number) => {
-              return <VideoPlayer key={index} data={video} />
-            })}
-          </Group>
+          {width >= 640 && (
+            <Group align="center" justify="center" grow wrap="wrap">
+              {YTVideoData?.items?.map((video: any, index: number) => {
+                return <VideoPlayer key={index} data={video} />
+              })}
+            </Group>
+          )}
+          {width < 640 && (
+            <Stack>
+              {YTVideoData?.items?.map((video: any, index: number) => {
+                return <VideoPlayer key={index} data={video} />
+              })}
+            </Stack>
+          )}
         </>
       )}
       {channelData === null && YTVideoData === null && (


### PR DESCRIPTION
mobile was just showing recent videos as 50% width which looked bad on mobile, this ensures videos will always be a decent width regardless of device or screen size