### PR TITLE
fix: truncate titles better

### DIFF
--- a/app/routes/playlist.$playlist.tsx
+++ b/app/routes/playlist.$playlist.tsx
@@ -11,7 +11,7 @@ import Splash from '~/components/organisms/splash'
 import { getPlayListItems } from '~/models/fetchYT.server'
 import classes from '~/styles/root.styles.module.css'
 import { cache } from '~/utils/db.server'
-import { findIndex, truncate } from '~/utils/utils'
+import { findIndex, truncate, truncateTitleLength } from '~/utils/utils'
 
 export const meta: MetaFunction = (data: any) => {
   const title = `${
@@ -30,9 +30,10 @@ export const meta: MetaFunction = (data: any) => {
         data?.matches[2]?.params?.playlist
       )
     ]?.snippet?.description || 'Playlist Description'
+  const titleEnd = ' | Youtube Playlist | FE-Engineer'
 
   return [
-    { title: truncate(`${title} | Youtube Playlist | FE-Engineer`, 67) },
+    { title: `${truncate(title, truncateTitleLength(titleEnd))}${titleEnd}` },
     {
       name: 'description',
       content: truncate(`${description}`, 157),

--- a/app/routes/videos.$video.tsx
+++ b/app/routes/videos.$video.tsx
@@ -6,7 +6,7 @@ import Splash from '~/components/organisms/splash'
 import { getVideo } from '~/models/fetchYT.server'
 import classes from '~/styles/root.styles.module.css'
 import { cache } from '~/utils/db.server'
-import { truncate } from '~/utils/utils'
+import { truncate, truncateTitleLength } from '~/utils/utils'
 
 export const meta: MetaFunction = ({ data }: any) => {
   const snippet = data?.videoData?.items[0]?.snippet
@@ -25,9 +25,10 @@ export const meta: MetaFunction = ({ data }: any) => {
     snippet?.thumbnails?.medium?.url || '',
     snippet?.thumbnails?.standard?.url || '',
   ]
+  const titleEnd = ' | Video | FE-Engineer'
 
   return [
-    { title: truncate(`${title} | Youtube Video | FE-Engineer`, 67) },
+    { title: `${truncate(title, truncateTitleLength(titleEnd))}${titleEnd}` },
     {
       name: 'description',
       content: truncate(`${description}`, 157),

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -36,3 +36,7 @@ export const truncate = (str: string, length: number) => {
   }
   return str
 }
+
+export const truncateTitleLength = (str: string) => {
+  return 70 - str.length
+}


### PR DESCRIPTION
videos may not be considered as main part of content due to titles being truncated from the end